### PR TITLE
Ensure all links route to correct language

### DIFF
--- a/ams/templates/cms/blocks/full_width_section_block.html
+++ b/ams/templates/cms/blocks/full_width_section_block.html
@@ -1,4 +1,4 @@
-{% load wagtailcore_tags wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags localise_url %}
 
 {# Full-width section that breaks out of the container #}
 <div class="full-width-section bg-body-tertiary text-body-tertiary"
@@ -17,7 +17,7 @@
       <div class="full-width-section__items full-width-section__items--{{ self.item_shape|default:'default' }}">
         {% for item in self.items %}
           {% if item.link_page or item.link_url %}
-            <a href="{% if item.link_page %}{% pageurl item.link_page %}{% else %}{{ item.link_url }}{% endif %}"
+            <a href="{% if item.link_page %}{% pageurl item.link_page %}{% else %}{{ item.link_url|localise_url }}{% endif %}"
                class="full-width-section__item full-width-section__item--{{ self.item_shape|default:'default' }} h-100 bg-body-tertiary text-body-tertiary"
                data-bs-theme="{{ item.colour_mode }}">
               {% include "cms/blocks/partials/full_width_section_item_content.html" %}

--- a/ams/templates/cms/blocks/image_grid_block.html
+++ b/ams/templates/cms/blocks/image_grid_block.html
@@ -1,4 +1,4 @@
-{% load wagtailcore_tags wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags localise_url %}
 
 <div class="image-grid row row-cols-2 row-cols-lg-{{ self.columns }} g-4 {% if self.image_alignment == 'center' %}justify-content-center{% endif %} {% if self.image_vertical_alignment == 'center' %}align-items-center{% endif %}">
   {% for item in self.items %}
@@ -26,7 +26,7 @@
           </div>
           {% comment %} (item.title and item.link_page) or (item.title and item.link_url) {% endcomment %}
           {% if item.title and item.link_page or item.title and item.link_url %}
-            <a href="{% if item.link_page %}{% pageurl item.link_page %}{% else %}{{ item.link_url }}{% endif %}"
+            <a href="{% if item.link_page %}{% pageurl item.link_page %}{% else %}{{ item.link_url|localise_url }}{% endif %}"
                class="stretched-link">
               <h4 class="image-grid__item__title h5 mb-2 {% if self.text_alignment == 'center' %} text-center {% else %} text-start {% endif %}">
                 {{ item.title }}
@@ -39,7 +39,7 @@
               </h4>
             {% endif %}
             {% if item.link_page or item.link_url %}
-              <a href="{% if item.link_page %}{% pageurl item.link_page %}{% else %}{{ item.link_url }}{% endif %}"
+              <a href="{% if item.link_page %}{% pageurl item.link_page %}{% else %}{{ item.link_url|localise_url }}{% endif %}"
                  class="stretched-link"></a>
             {% endif %}
           {% endif %}

--- a/ams/templates/cms/menu/desktop_child_item.html
+++ b/ams/templates/cms/menu/desktop_child_item.html
@@ -1,9 +1,9 @@
-{% load menu_tags %}
+{% load menu_tags localise_url %}
 
 {% for item in menu_items %}
   <li>
     <a class="dropdown-item{% if item.active_class %} active{% endif %}"
-       href="{{ item.href }}"
+       href="{{ item.href|localise_url:request.LANGUAGE_CODE }}"
        {% if item.active_class %}aria-current="true"{% endif %}>{{ item.text }}</a>
   </li>
 {% endfor %}

--- a/ams/templates/cms/menu/desktop_top_level_item.html
+++ b/ams/templates/cms/menu/desktop_top_level_item.html
@@ -1,10 +1,10 @@
-{% load menu_tags %}
+{% load menu_tags localise_url %}
 
 {% for item in menu_items %}
   {% if item.has_children_in_menu %}
     <li class="nav-item dropdown">
       <a class="nav-link text-body-emphasis dropdown-toggle submenu"
-         href="{{ item.href }}"
+         href="{{ item.href|localise_url:request.LANGUAGE_CODE }}"
          id="menu-item-{{ forloop.counter }}"
          role="button"
          data-bs-toggle="dropdown"
@@ -17,7 +17,7 @@
   {% else %}
     <li class="nav-item">
       <a class="nav-link text-body-emphasis {% if item.active_class %}active{% endif %}"
-         href="{{ item.href }}"
+         href="{{ item.href|localise_url:request.LANGUAGE_CODE }}"
          {% if item.active_class %}aria-current="page"{% endif %}>{{ item.text }}</a>
     </li>
   {% endif %}

--- a/ams/templates/cms/menu/footer_menu.html
+++ b/ams/templates/cms/menu/footer_menu.html
@@ -1,10 +1,10 @@
-{% load menu_tags %}
+{% load menu_tags localise_url %}
 
 {% if show_menu_heading and menu_heading %}<h5 class="text-body-emphasis mb-2">{{ menu_heading|safe }}</h5>{% endif %}
 <ul class="nav flex-column">
   {% for item in menu_items %}
     <li class="nav-item mb-2">
-      <a href="{{ item.href }}"
+      <a href="{{ item.href|localise_url:request.LANGUAGE_CODE }}"
          class="nav-link p-0 text-body-secondary{% if item.active_class %} active{% endif %}"
          {% if item.active_class %}aria-current="true"{% endif %}>{{ item.text }}</a>
     </li>

--- a/ams/templates/cms/menu/mobile_child_item.html
+++ b/ams/templates/cms/menu/mobile_child_item.html
@@ -1,9 +1,9 @@
-{% load menu_tags %}
+{% load menu_tags localise_url %}
 
 {% for item in menu_items %}
   <li class="nav-item">
     <a class="nav-link {% if item.active_class %}active{% endif %}"
-       href="{{ item.href }}"
+       href="{{ item.href|localise_url:request.LANGUAGE_CODE }}"
        {% if item.active_class %}aria-current="page"{% endif %}>{{ item.text }}</a>
   </li>
 {% endfor %}

--- a/ams/templates/cms/menu/mobile_top_level_item.html
+++ b/ams/templates/cms/menu/mobile_top_level_item.html
@@ -1,9 +1,9 @@
-{% load menu_tags %}
+{% load menu_tags localise_url %}
 
 {% for item in menu_items %}
   <li class="nav-item">
     <a class="nav-link {% if item.active_class %}active{% endif %}"
-       href="{{ item.href }}"
+       href="{{ item.href|localise_url:request.LANGUAGE_CODE }}"
        {% if item.active_class %}aria-current="page"{% endif %}>{{ item.text }}</a>
     {% if item.has_children_in_menu %}
       <ul class="nav flex-column ms-3">

--- a/ams/utils/templatetags/breadcrumbs.py
+++ b/ams/utils/templatetags/breadcrumbs.py
@@ -42,7 +42,7 @@ def breadcrumbs(context):
         # Add home
         breadcrumb_list.append(
             {
-                "url": "/",
+                "url": f"/{request.LANGUAGE_CODE}/",
                 "title": _("Home"),
                 "is_active": False,
             },

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -279,6 +279,7 @@ TEMPLATES = [
             "libraries": {
                 "icon": "config.templatetags.icon",
                 "translate_url": "config.templatetags.translate_url",
+                "localise_url": "config.templatetags.localise_url",
                 "theme": "ams.cms.templatetags.theme",
                 "breadcrumbs": "ams.utils.templatetags.breadcrumbs",
                 "utils": "ams.utils.templatetags.utils",

--- a/config/templatetags/localise_url.py
+++ b/config/templatetags/localise_url.py
@@ -1,0 +1,33 @@
+"""Module for the custom localise_url template filter."""
+
+from django.conf import settings
+from django.template import Library
+from django.utils.translation import get_language
+
+register = Library()
+
+
+def _get_valid_lang_codes():
+    return frozenset(code for code, name in settings.LANGUAGES)
+
+
+@register.filter
+def localise_url(url, language_code=None):
+    """Add language prefix to internal URLs that lack one.
+
+    Falls back to the active language from get_language() when no language_code
+    is passed — safe to use in block templates that don't have request in context.
+    """
+    if not url:
+        return url
+    if not language_code:
+        language_code = get_language()
+    if not language_code:
+        return url
+    if "://" in url or url.startswith("#"):
+        return url
+    valid_lang_codes = _get_valid_lang_codes()
+    parts = url.lstrip("/").split("/")
+    if parts and parts[0] in valid_lang_codes:
+        return url
+    return f"/{language_code}/{url.lstrip('/')}"

--- a/config/tests/test_localise_url.py
+++ b/config/tests/test_localise_url.py
@@ -1,0 +1,44 @@
+import pytest
+from django.test.utils import override_settings
+from django.utils import translation
+
+from config.templatetags.localise_url import localise_url
+
+
+@override_settings(LANGUAGES=[("en", "English"), ("mi", "Te Reo Māori")])
+def test_localise_url_falls_back_to_active_language():
+    """Without a language_code arg, localise_url uses the active language."""
+    with translation.override("mi"):
+        assert localise_url("/events/") == "/mi/events/"
+    with translation.override("en"):
+        assert localise_url("/events/") == "/en/events/"
+
+
+@pytest.mark.parametrize(
+    ("url", "language_code", "expected"),
+    [
+        # Internal URL without prefix gets prefixed
+        ("/events/", "mi", "/mi/events/"),
+        ("/events/", "en", "/en/events/"),
+        # Already prefixed URLs are unchanged
+        ("/mi/events/", "mi", "/mi/events/"),
+        ("/en/events/", "en", "/en/events/"),
+        ("/mi/events/", "en", "/mi/events/"),
+        # External URLs are unchanged
+        ("https://example.com/path/", "mi", "https://example.com/path/"),
+        ("http://example.com/", "en", "http://example.com/"),
+        # Fragment-only links are unchanged
+        ("#section", "mi", "#section"),
+        # Empty/None inputs return as-is
+        ("", "mi", ""),
+        (None, "mi", None),
+        # URL without leading slash
+        ("events/", "mi", "/mi/events/"),
+        # Trailing slash is preserved
+        ("/resources/", "mi", "/mi/resources/"),
+    ],
+)
+@override_settings(LANGUAGES=[("en", "English"), ("mi", "Te Reo Māori")])
+def test_localise_url(url, language_code, expected):
+    """Test localise_url filter adds language prefix to unlocalized internal URLs."""
+    assert localise_url(url, language_code) == expected


### PR DESCRIPTION
Fixes an issue where links not prefixed by a language were always routing to English.