### PR TITLE
Disable gunicorn CLI

### DIFF
--- a/compose/production/django/start-web.sh
+++ b/compose/production/django/start-web.sh
@@ -15,6 +15,7 @@ exec /usr/local/bin/gunicorn config.wsgi \
   --threads 1 \
   --timeout 30 \
   --chdir=/app \
+  --no-control-socket \
   --access-logfile - \
   --error-logfile - \
   --log-level info \


### PR DESCRIPTION
This is not required for containered usage, and is causing issues on startup due to no access to a valid directory.