### PR TITLE
Don't add language to menu links outside i18n_patterns

### DIFF
--- a/config/templatetags/localise_url.py
+++ b/config/templatetags/localise_url.py
@@ -1,7 +1,11 @@
 """Module for the custom localise_url template filter."""
 
+from urllib.parse import urlsplit
+
 from django.conf import settings
 from django.template import Library
+from django.urls import Resolver404
+from django.urls import resolve
 from django.utils.translation import get_language
 
 register = Library()
@@ -11,12 +15,38 @@ def _get_valid_lang_codes():
     return frozenset(code for code, name in settings.LANGUAGES)
 
 
+def _resolves_without_language_prefix(path):
+    """Return True if `path` resolves to a view without an i18n language prefix.
+
+    Apps registered outside i18n_patterns() in config/urls.py (forum/, billing/,
+    cms/, cms-documents/) must never get a language prefix. Rather than
+    hardcoding that list, ask the resolver directly: if the path already
+    resolves on its own, it doesn't need one.
+    """
+    if not path.startswith("/"):
+        path = f"/{path}"
+    candidates = [path]
+    if settings.APPEND_SLASH and not path.endswith("/"):
+        candidates.append(f"{path}/")
+    for candidate in candidates:
+        try:
+            resolve(candidate)
+        except Resolver404:
+            continue
+        return True
+    return False
+
+
 @register.filter
 def localise_url(url, language_code=None):
     """Add language prefix to internal URLs that lack one.
 
     Falls back to the active language from get_language() when no language_code
     is passed — safe to use in block templates that don't have request in context.
+
+    URLs that already resolve without a language prefix (e.g. /forum/, /cms/,
+    /billing/..., /cms-documents/..., registered outside i18n_patterns() in
+    config/urls.py) are left untouched.
     """
     if not url:
         return url
@@ -29,5 +59,7 @@ def localise_url(url, language_code=None):
     valid_lang_codes = _get_valid_lang_codes()
     parts = url.lstrip("/").split("/")
     if parts and parts[0] in valid_lang_codes:
+        return url
+    if _resolves_without_language_prefix(urlsplit(url).path):
         return url
     return f"/{language_code}/{url.lstrip('/')}"

--- a/config/tests/test_localise_url.py
+++ b/config/tests/test_localise_url.py
@@ -36,6 +36,31 @@ def test_localise_url_falls_back_to_active_language():
         ("events/", "mi", "/mi/events/"),
         # Trailing slash is preserved
         ("/resources/", "mi", "/mi/resources/"),
+        # Non-i18n app roots (registered outside i18n_patterns in
+        # config/urls.py) stay unprefixed regardless of language.
+        ("/forum/", "en", "/forum/"),
+        ("/forum/", "mi", "/forum/"),
+        # No trailing slash — exercises the APPEND_SLASH resolve() fallback.
+        ("/forum", "en", "/forum"),
+        # Wagtail admin root.
+        ("/cms/", "en", "/cms/"),
+        # Billing endpoint (billing/ itself has no root view — use a real
+        # leaf route).
+        ("/billing/xero/webhooks/", "en", "/billing/xero/webhooks/"),
+        # Wagtail document serve endpoint (cms-documents/ has no root view
+        # either).
+        ("/cms-documents/1/test-file.pdf", "en", "/cms-documents/1/test-file.pdf"),
+        # Query string / fragment are preserved and don't break the
+        # resolve() check.
+        ("/forum/?tab=active", "en", "/forum/?tab=active"),
+        ("/forum/#top", "en", "/forum/#top"),
+        # Root redirect view — deliberate behavior change: this now
+        # resolves without a prefix, so it's left as the user's
+        # preferred-language root rather than forced to /en/.
+        ("/", "en", "/"),
+        # Genuinely unresolvable path still falls back to prefixing
+        # (regression guard for the fail-safe design).
+        ("/does-not-exist/", "en", "/en/does-not-exist/"),
     ],
 )
 @override_settings(LANGUAGES=[("en", "English"), ("mi", "Te Reo Māori")])


### PR DESCRIPTION
Custom Wagtail menu links (e.g. /forum/) were being rewritten to /en/forum/ by the localise_url filter, which unconditionally prepended a language prefix to any relative URL. This 404ed because forum/, billing/, cms/, and cms-documents/ are intentionally registered outside i18n_patterns() in config/urls.py.

localise_url now uses resolve() to check whether a URL already resolves without a prefix before deciding to add one, so it stays in sync with config/urls.py without a hardcoded exclusion list.