### PR TITLE
Save invoices individually so paid_date save triggers membership approval

### DIFF
--- a/ams/billing/providers/xero/service.py
+++ b/ams/billing/providers/xero/service.py
@@ -550,7 +550,6 @@ class XeroBillingService(BillingService):
             billing_service_invoice_ids,
         )
 
-        invoices_to_update = []
         for accounting_invoice in invoices:
             invoice = Invoice.objects.get(
                 billing_service_invoice_id=accounting_invoice.invoice_id,
@@ -561,12 +560,12 @@ class XeroBillingService(BillingService):
             invoice.paid = accounting_invoice.amount_paid
             invoice.due = accounting_invoice.amount_due
             invoice.paid_date = accounting_invoice.fully_paid_on_date
-            invoices_to_update.append(invoice)
-
-        if invoices_to_update:
-            Invoice.objects.bulk_update(
-                invoices_to_update,
-                fields=[
+            # save() per-invoice (not bulk_update) so post_save fires and
+            # approve_memberships_on_invoice_payment can activate the
+            # linked membership. update_fields excludes update_needed /
+            # update_requested_at, which the caller owns exclusively.
+            invoice.save(
+                update_fields=[
                     "amount",
                     "issue_date",
                     "due_date",

--- a/ams/billing/providers/xero/tests/test_service.py
+++ b/ams/billing/providers/xero/tests/test_service.py
@@ -12,6 +12,9 @@ from xero_python.exceptions import AccountingBadRequestException
 from ams.billing.providers.xero.models import XeroContact
 from ams.billing.providers.xero.service import MockXeroBillingService
 from ams.billing.providers.xero.service import XeroBillingService
+from ams.billing.tests.factories import InvoiceFactory
+from ams.memberships.models import MembershipStatus
+from ams.memberships.tests.factories import IndividualMembershipFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -501,6 +504,52 @@ class TestXeroBillingServiceInvoiceManagement:
         assert invoice_user.paid_date is not None
         # The caller owns the flag - the service must leave it alone.
         assert invoice_user.update_needed is True
+
+    @patch("ams.billing.providers.xero.service.AccountingApi")
+    def test_update_invoices_activates_pending_individual_membership(
+        self,
+        mock_accounting_api_class,
+        xero_service,
+        account_user,
+        xero_settings,
+    ):
+        """Marking an invoice paid via the Xero poll approves its membership."""
+        membership = IndividualMembershipFactory(pending=True)
+        assert membership.status() == MembershipStatus.PENDING
+
+        invoice = InvoiceFactory(
+            account=account_user,
+            billing_service_invoice_id="test-invoice-456",
+            individual_membership=membership,
+            paid_date=None,
+        )
+
+        xero_invoice = XeroInvoiceModel(
+            invoice_id="test-invoice-456",
+            invoice_number="INV-002",
+            date="2024-01-15",
+            due_date="2024-02-15",
+            total=100.0,
+            amount_due=0.0,
+            amount_paid=100.0,
+            fully_paid_on_date="2024-01-20",
+        )
+        response = Mock()
+        response.invoices = [xero_invoice]
+
+        mock_api = Mock()
+        mock_api.get_invoices.return_value = response
+        mock_accounting_api_class.return_value = mock_api
+
+        with patch.object(xero_service, "_get_authentication_token"):
+            xero_service.update_invoices(["test-invoice-456"])
+
+        invoice.refresh_from_db()
+        assert invoice.paid_date is not None
+
+        membership.refresh_from_db()
+        assert membership.approved_datetime is not None
+        assert membership.status() == MembershipStatus.ACTIVE
 
 
 class TestXeroBillingServiceAuthentication:


### PR DESCRIPTION
Invoices marked paid via the Xero poll (fetch_invoice_updates -> fetch_updated_invoice_details -> XeroBillingService.update_invoices) were never activating their linked membership. Membership approval is driven by approve_memberships_on_invoice_payment, a post_save signal on Invoice that calls MembershipBillingService.approve_paid_memberships whenever an existing invoice is saved with paid_date set - the only code path that sets membership.approved_datetime, which BaseMembership.status() checks to leave PENDING.

update_invoices persisted fetched data with Invoice.objects.bulk_update, which Django never routes through post_save, so the signal silently never fired on this path and memberships stayed pending indefinitely.

Replace the bulk_update with a per-invoice save(update_fields=[...]), keeping the same six fields (amount, issue_date, due_date, paid, due, paid_date) so update_needed/update_requested_at are left untouched.

Adds a regression test exercising update_invoices end-to-end against a pending IndividualMembership, since no test previously covered the invoice-paid -> membership-approved integration path at all.